### PR TITLE
Allow IP certs for IP alt-hosts

### DIFF
--- a/draft-bishop-httpbis-sni-altsvc.md
+++ b/draft-bishop-httpbis-sni-altsvc.md
@@ -112,7 +112,8 @@ Syntax:
 
 When processing such an alternative, clients SHOULD present the hostname given
 in the `sni` parameter in the SNI extension during the TLS handshake. If the
-hostname given is an empty string, clients SHOULD omit the SNI extension from
+hostname given is an IP literal or an empty string,
+clients SHOULD omit the SNI extension from
 the TLS handshake.  The server MUST return a valid certificate which covers
 at least one of the following:
 
@@ -123,7 +124,7 @@ at least one of the following:
 The client MUST validate the certificate in the handshake for authenticity
 according to {{!RFC2818}} and ensure that it is valid for at least one of these
 names.  Clients SHOULD NOT accept certificates issued to the IP address of the
-alternative.
+alternative unless the alternative is specified as an IP literal.
 
 If the certificate is not valid for the origin's hostname, the client MUST NOT
 make requests to any origin corresponding to this certificate. In this case, the

--- a/draft-bishop-httpbis-sni-altsvc.md
+++ b/draft-bishop-httpbis-sni-altsvc.md
@@ -105,15 +105,14 @@ parameter in its alternative service entry.
 
 Syntax:
 
-    sni = ( host / empty-string )
+    sni = ( reg-name / empty-string )
     empty-string = DQUOTE DQUOTE
 
-`host` is defined in Section 3.2.2 of {{!RFC3986}}.
+`reg-name` is defined in Section 3.2.2 of {{!RFC3986}}.
 
 When processing such an alternative, clients SHOULD present the hostname given
 in the `sni` parameter in the SNI extension during the TLS handshake. If the
-hostname given is an IP literal or an empty string,
-clients SHOULD omit the SNI extension from
+hostname given is an empty string, clients SHOULD omit the SNI extension from
 the TLS handshake.  The server MUST return a valid certificate which covers
 at least one of the following:
 


### PR DESCRIPTION
I'm not entirely confident what the right logic is for this, but allowing IP certs if the alternative is an IP address seems reasonable.

Also, the current instructions allow an IP literal SNI and tell the client to put it in the SNI field, which I think is bizarre (and possibly a violation of the SNI spec).