### PR TITLE
Frames of reserved type are not subject to flow control.

### DIFF
--- a/draft-bishop-httpbis-grease.md
+++ b/draft-bishop-httpbis-grease.md
@@ -63,6 +63,7 @@ These frames have no semantic meaning, and SHOULD be send instead of using
 padding on DATA or HEADERS frames where possible.  They MAY also be sent on
 connections where there is no application data currently being transferred.
 Endpoints MUST NOT consider these frames to have any meaning upon receipt.
+These frames are not subject to flow control.
 
 The flags, the payload, and the length of the frames SHOULD be selected
 randomly, subject to implementation-defined limits on the length.


### PR DESCRIPTION
RFC7540 only specifies the frame types subject to flow control among the
frame types defined within: "Of the frames specified in this document,
only DATA frames are subject to flow control; all other frame types do
not consume space in the advertised flow-control window." (Secton 5.2.1)
It allows extensions to define new frame types and make them subject to
flow control or not ("treating any frames other than DATA frames as flow
controlled [...]" in Section 5.5).

This PR explicitly states that frames of reserved types are not subject
to flow control.